### PR TITLE
Missing import: sys

### DIFF
--- a/xfrserver/xfrserver.py
+++ b/xfrserver/xfrserver.py
@@ -1,6 +1,7 @@
 import dns, dns.rcode, dns.zone
 import socket
 import struct
+import sys
 import threading
 
 class AXFRServer(object):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/PowerDNS/xfrserver on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./xfrserver/xfrserver.py:108:13: F821 undefined name 'sys'
            sys.exit(1)
            ^
./xfrserver/xfrserver.py:130:13: F821 undefined name 'sys'
            sys.exit(1)
            ^
2     F821 undefined name 'sys'
2
```